### PR TITLE
add ability to hide Vertical Tabs

### DIFF
--- a/chrome/content/ff-overlay.js
+++ b/chrome/content/ff-overlay.js
@@ -23,7 +23,8 @@ let SimplyPinnedMain =
     DEFAULT_TOOLBAR_IDS : new Array("toolbar-menubar",
                                     "nav-bar",
                                     "PersonalToolbar",
-                                    "addon-bar"),
+                                    "addon-bar",
+                                    "verticaltabs-box"),
     
     /**
      * Toolbars that are all controlled by a single preference and that aren't

--- a/chrome/content/options.xul
+++ b/chrome/content/options.xul
@@ -23,6 +23,8 @@
                 name="extensions.simplypinned.bool_PersonalToolbar" />
             <preference id="boolpref_addon-bar" type="bool" 
                 name="extensions.simplypinned.bool_addon-bar" />
+            <preference id="boolpref_verticaltabs-box" type="bool" 
+                name="extensions.simplypinned.bool_verticaltabs-box" />
             <preference id="boolpref_otherToolbars" type="bool" 
                 name="extensions.simplypinned.bool_otherToolbars" />
             <!-- Preferences for hotkey to toggle -->
@@ -50,6 +52,9 @@
             <checkbox id="chk_addon-bar"
                 label="&chk_addon-bar.label;"
                 preference="boolpref_addon-bar"/>
+            <checkbox id="chk_verticaltabs-box"
+                label="&chk_verticaltabs-box.label;"
+                preference="boolpref_verticaltabs-box"/>
             <checkbox id="chk_otherToolbars"
                 label="&chk_otherToolbars.label;"
                 preference="boolpref_otherToolbars"/>

--- a/chrome/locale/en-US/options.dtd
+++ b/chrome/locale/en-US/options.dtd
@@ -6,6 +6,7 @@
 <!ENTITY chk_nav-bar.label          "Navigation Toolbar">
 <!ENTITY chk_PersonalToolbar.label  "Bookmarks Toolbar">
 <!ENTITY chk_addon-bar.label        "Add-on Bar">
+<!ENTITY chk_verticaltabs-box.label "Vertical Tabs">
 <!ENTITY chk_otherToolbars.label    "Other Toolbars:">
 
 <!ENTITY simplypinned-toggle-hotkey-caption.label


### PR DESCRIPTION
This was relatively straightforward. One thing missing is the ability to also hide #verticaltabs-splitter, because your foreach routine just looks for simple IDs and I don't have more time at the moment to enhance that. Comments and further ideas welcome, on how to make one preference control >1 XUL ID.
